### PR TITLE
[Zvkb] Adding missing support for unmasked variants of Zvkb intrinsics

### DIFF
--- a/src/rie_generator/zvkb_emulation.py
+++ b/src/rie_generator/zvkb_emulation.py
@@ -189,7 +189,7 @@ def generate_zvkb_emulation(attributes: list[str], prototypes: bool, definitions
     all_elt_types = [EltType.U8, EltType.U16, EltType.U32, EltType.U64]
     all_lmuls = [LMULType.M1, LMULType.M2, LMULType.M4, LMULType.M8]
     all_tail_policies = [TailPolicy.UNDISTURBED, TailPolicy.AGNOSTIC]
-    all_mask_policies = [MaskPolicy.UNDISTURBED, MaskPolicy.AGNOSTIC]
+    all_mask_policies = [MaskPolicy.UNDISTURBED, MaskPolicy.AGNOSTIC, MaskPolicy.UNMASKED]
 
     elt_types = [e for e in all_elt_types if elt_filter is None or e in elt_filter]
     lmuls = [l for l in all_lmuls if lmul_filter is None or l in lmul_filter]


### PR DESCRIPTION
Zvkb could not generate unmasked variants, it would generate no implementations when called to generate only unmasked variants.
```
 python3 scripts/generate_emulation.py -e zvkb --elt-width 64 --lmul m1 --mask-policy um 
/* ===== Zvkb Emulation ===== */
#include <stdint.h>

#include <riscv_vector.h>

#include <stddef.h>
```