### PR TITLE
Adding label filtering capabilities from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Python code generator that produces C functions emulating RISC-V vector extens
 
 ## Overview
 
-Some RISC-V vector extensions (e.g. Zvkb for vector crypto bit-manipulation, Zvdot4a8i for packed 8-bit integer dot products, Zvzip for vector interleave/deinterleave, Zvabd for absolute value/difference) introduce new instructions that may not yet be available on all hardware. This tool automatically generates C emulation functions that implement the same semantics using base RVV 1.0 instructions.
+Some RISC-V vector extensions introduce new instructions that may not yet be available on all hardware. This tool generates C emulation functions that implement the new instructions' semantics using base RVV 1.0 instructions.
 
 ### Supported Extensions
 

--- a/scripts/generate_emulation.py
+++ b/scripts/generate_emulation.py
@@ -108,6 +108,12 @@ def main():
         default=None,
         help='Mask policies to generate (default: all). Values: mu (undisturbed), ma (agnostic), um (unmasked)'
     )
+    parser.add_argument(
+        '--label-filter',
+        type=str,
+        default=None,
+        help='Regex pattern to filter generated intrinsics by name (applied to the full __riscv_v* label)'
+    )
     args = parser.parse_args()
     
     # Convert CLI strings to enum values (None means "all")
@@ -120,6 +126,7 @@ def main():
         elt_width_filter = None
     tail_policy_filter = [TAIL_POLICY_MAP[t] for t in args.tail_policy] if args.tail_policy else None
     mask_policy_filter = [MASK_POLICY_MAP[m] for m in args.mask_policy] if args.mask_policy else None
+    label_filter = args.label_filter
 
     output = []
     
@@ -133,6 +140,7 @@ def main():
             elt_filter=elt_width_filter,
             tail_policy_filter=tail_policy_filter,
             mask_policy_filter=mask_policy_filter,
+            label_filter=label_filter,
         ))
     
     if args.extension in ('zvdot4a8i', 'all'):
@@ -144,6 +152,7 @@ def main():
             lmul_filter=lmul_filter,
             tail_policy_filter=tail_policy_filter,
             mask_policy_filter=mask_policy_filter,
+            label_filter=label_filter,
         ))
 
     if args.extension in ('zvzip', 'all'):
@@ -156,6 +165,7 @@ def main():
             elt_filter=elt_width_filter,
             tail_policy_filter=tail_policy_filter,
             mask_policy_filter=mask_policy_filter,
+            label_filter=label_filter,
         ))
 
     if args.extension in ('zvabd', 'all'):
@@ -168,6 +178,7 @@ def main():
             elt_filter=elt_width_filter,
             tail_policy_filter=tail_policy_filter,
             mask_policy_filter=mask_policy_filter,
+            label_filter=label_filter,
         ))
     
     result = "\n".join(output)

--- a/src/rie_generator/zvabd_emulation.py
+++ b/src/rie_generator/zvabd_emulation.py
@@ -1,3 +1,5 @@
+import re
+
 """
 Zvabd instruction emulation generator.
 
@@ -17,6 +19,7 @@ from .core import (
     EltType,
     LMULType,
     OperationType,
+    generate_intrinsic_name,
     generate_intrinsic_prototype,
     generate_intrinsic_from_operation,
     TailPolicy,
@@ -164,6 +167,7 @@ def generate_zvabd_emulation(
     elt_filter: list = None,
     tail_policy_filter: list = None,
     mask_policy_filter: list = None,
+    label_filter: str = None,
 ):
     """Generate all Zvabd instruction emulations.
 
@@ -306,6 +310,8 @@ def generate_zvabd_emulation(
                         zvabd_insns.append((vwabda_vv_prototype, vwabda_vv_emulation))
                         zvabd_insns.append((vwabdau_vv_prototype, vwabdau_vv_emulation))
 
+                    if label_filter is not None:
+                        zvabd_insns = [(p, e) for p, e in zvabd_insns if re.search(label_filter, generate_intrinsic_name(p))]
                     if prototypes:
                         output.append("// prototypes")
                         for proto, _ in zvabd_insns:

--- a/src/rie_generator/zvdot4a8i_emulation.py
+++ b/src/rie_generator/zvdot4a8i_emulation.py
@@ -1,3 +1,5 @@
+import re
+
 """
 Zvdot4a8i (Vector 4-element Dot Product of packed 8-bit Integers)
 instruction emulation generator.
@@ -27,6 +29,7 @@ from .core import (
     expand_reinterpret_cast,
     LMULType,
     OperationType,
+    generate_intrinsic_name,
     generate_intrinsic_prototype,
     generate_intrinsic_from_operation,
     TailPolicy,
@@ -200,7 +203,8 @@ VALID_32BIT_LMULS = [LMULType.M1, LMULType.M2, LMULType.M4, LMULType.M8]
 
 
 def generate_zvdot4a8i_emulation(attributes: list[str] = [], prototypes: bool = False, definitions: bool = True,
-                                  lmul_filter: list = None, tail_policy_filter: list = None, mask_policy_filter: list = None):
+                                  lmul_filter: list = None, tail_policy_filter: list = None, mask_policy_filter: list = None,
+                                  label_filter: str = None):
     """Generate all Zvdot4a8i instruction emulations.
 
     Args:
@@ -331,6 +335,8 @@ def generate_zvdot4a8i_emulation(attributes: list[str] = [], prototypes: bool = 
                 tail_policy_str = TailPolicy.to_string(tail_policy)
                 mask_policy_str = MaskPolicy.to_string(mask_policy)
 
+                if label_filter is not None:
+                    zvdot4a8i_insns = [(p, e) for p, e in zvdot4a8i_insns if re.search(label_filter, generate_intrinsic_name(p))]
                 if prototypes:
                     output.append(f"// Zvdot4a8i prototypes (LMUL={lmul_str}), tail_policy={tail_policy_str}, mask_policy={mask_policy_str}")
                     for proto, _ in zvdot4a8i_insns:

--- a/src/rie_generator/zvkb_emulation.py
+++ b/src/rie_generator/zvkb_emulation.py
@@ -1,3 +1,5 @@
+import re
+
 """
 Zvkb (Vector Bit-manipulation) instruction emulation generator.
 
@@ -18,6 +20,7 @@ from .core import (
     EltType,
     LMULType,
     OperationType,
+    generate_intrinsic_name,
     generate_intrinsic_prototype,
     generate_intrinsic_from_operation,
     TailPolicy,
@@ -168,7 +171,8 @@ def rev8(op0: Node, vl: Node, vm: Node = None, dst: Node = None, tail_policy: Ta
 
 def generate_zvkb_emulation(attributes: list[str], prototypes: bool, definitions: bool,
                              lmul_filter: list = None, elt_filter: list = None,
-                             tail_policy_filter: list = None, mask_policy_filter: list = None):
+                             tail_policy_filter: list = None, mask_policy_filter: list = None,
+                             label_filter: str = None):
     """Generate all Zvkb rotate instruction emulations.
 
     Args:
@@ -329,6 +333,8 @@ def generate_zvkb_emulation(attributes: list[str], prototypes: bool, definitions
                         (vuintm_rev8_v_prototype, vuintm_rev8_v_emulation)
                     ]
 
+                    if label_filter is not None:
+                        zvkb_insns = [(p, e) for p, e in zvkb_insns if re.search(label_filter, generate_intrinsic_name(p))]
                     if prototypes:
                         output.append("// prototypes")
                         for prototype in [p for p, e in zvkb_insns]:

--- a/src/rie_generator/zvzip_emulation.py
+++ b/src/rie_generator/zvzip_emulation.py
@@ -1,3 +1,5 @@
+import re
+
 """
 Zvzip instruction emulation generator.
 
@@ -17,6 +19,7 @@ from .core import (
     EltType,
     LMULType,
     OperationType,
+    generate_intrinsic_name,
     generate_intrinsic_prototype,
     generate_intrinsic_from_operation,
     TailPolicy,
@@ -369,6 +372,7 @@ def generate_zvzip_emulation(
     elt_filter: list = None,
     tail_policy_filter: list = None,
     mask_policy_filter: list = None,
+    label_filter: str = None,
 ):
     """Generate all Zvzip instruction emulations.
 
@@ -499,6 +503,8 @@ def generate_zvzip_emulation(
                         (vpair_odd_prototype, vpair_odd_emulation),
                     ]
 
+                    if label_filter is not None:
+                        zvzip_insns = [(p, e) for p, e in zvzip_insns if re.search(label_filter, generate_intrinsic_name(p))]
                     if prototypes:
                         output.append("// prototypes")
                         for proto, _ in zvzip_insns:


### PR DESCRIPTION
Adding a new command line option, `--label-filter` which accepts a regular expression and only limit the intrinsic generation to the label matching the regex provided as argument.