### PR TITLE
[Zvqwdota8i] Implementing support for long dot product emulation

### DIFF
--- a/scripts/generate_emulation.py
+++ b/scripts/generate_emulation.py
@@ -16,6 +16,7 @@ from rie_generator.zvkb_emulation import generate_zvkb_emulation
 from rie_generator.zvdot4a8i_emulation import generate_zvdot4a8i_emulation
 from rie_generator.zvzip_emulation import generate_zvzip_emulation
 from rie_generator.zvabd_emulation import generate_zvabd_emulation
+from rie_generator.zvdota_emulation import generate_zvdota_emulation
 from rie_generator.core import LMULType, EltType, TailPolicy, MaskPolicy
 
 # Maps CLI string values to enum values
@@ -51,7 +52,7 @@ def main():
     )
     parser.add_argument(
         '--extension', '-e',
-        choices=['zvkb', 'zvdot4a8i', 'zvzip', 'zvabd', 'all'],
+        choices=['zvkb', 'zvdot4a8i', 'zvzip', 'zvabd', 'zvdota', 'all'],
         default='all',
         help='Which extension to generate emulation for (default: all)'
     )
@@ -176,6 +177,18 @@ def main():
             definitions=not args.no_definitions,
             lmul_filter=lmul_filter,
             elt_filter=elt_width_filter,
+            tail_policy_filter=tail_policy_filter,
+            mask_policy_filter=mask_policy_filter,
+            label_filter=label_filter,
+        ))
+
+    if args.extension in ('zvdota', 'all'):
+        output.append("\n/* ===== Zvdota Emulation ===== */")
+        output.append(generate_zvdota_emulation(
+            attributes=args.attributes,
+            prototypes=args.prototypes,
+            definitions=not args.no_definitions,
+            lmul_filter=lmul_filter,
             tail_policy_filter=tail_policy_filter,
             mask_policy_filter=mask_policy_filter,
             label_filter=label_filter,

--- a/src/rie_generator/core.py
+++ b/src/rie_generator/core.py
@@ -202,6 +202,12 @@ class OperationType(Enum):
     DOT4AU = auto()
     DOT4ASU = auto()
     DOT4AUS = auto()
+    # Zvdota family: scalar dot products
+    QWDOTAU = auto()   # vqwdotau.vv (unsigned vs2, altfmt-selected vs1)
+    QWDOTAS = auto()   # vqwdotas.vv (signed vs2, altfmt-selected vs1)
+    FWDOTA = auto()     # vfwdota.vv (BF16 dot product)
+    FQWDOTA = auto()    # vfqwdota.vv (OFP8 E4M3 vs2)
+    FQWDOTA_ALT = auto() # vfqwdota.alt.vv (OFP8 E5M2 vs2)
     WMUL = auto()
     WMULU = auto()
     WMULSU = auto()
@@ -294,6 +300,16 @@ class OperationType(Enum):
             return "dot4asu"
         elif op_type == OperationType.DOT4AUS:
             return "dot4aus"
+        elif op_type == OperationType.QWDOTAU:
+            return "qwdotau"
+        elif op_type == OperationType.QWDOTAS:
+            return "qwdotas"
+        elif op_type == OperationType.FWDOTA:
+            return "fwdota"
+        elif op_type == OperationType.FQWDOTA:
+            return "fqwdota"
+        elif op_type == OperationType.FQWDOTA_ALT:
+            return "fqwdota_alt"
         elif op_type == OperationType.WMUL:
             return "wmul"
         elif op_type == OperationType.WMULU:

--- a/src/rie_generator/core.py
+++ b/src/rie_generator/core.py
@@ -27,6 +27,10 @@ class EltType(Enum):
         return elt_type in [EltType.S8, EltType.S16, EltType.S32, EltType.S64]
 
     @staticmethod
+    def is_unsigned(elt_type: 'EltType') -> bool:
+        return elt_type in [EltType.U8, EltType.U16, EltType.U32, EltType.U64]
+
+    @staticmethod
     def inverse_sign(elt_type: 'EltType') -> 'EltType':
         if elt_type == EltType.U8:
             return EltType.S8
@@ -203,8 +207,7 @@ class OperationType(Enum):
     DOT4ASU = auto()
     DOT4AUS = auto()
     # Zvdota family: scalar dot products
-    QWDOTAU = auto()   # vqwdotau.vv (unsigned vs2, altfmt-selected vs1)
-    QWDOTAS = auto()   # vqwdotas.vv (signed vs2, altfmt-selected vs1)
+    QWDOTA = auto()   # vqwdota(u/s).vv
     FWDOTA = auto()     # vfwdota.vv (BF16 dot product)
     FQWDOTA = auto()    # vfqwdota.vv (OFP8 E4M3 vs2)
     FQWDOTA_ALT = auto() # vfqwdota.alt.vv (OFP8 E5M2 vs2)
@@ -244,6 +247,21 @@ class OperationType(Enum):
     ABDU = auto()
     WABDA = auto()
     WABDAU = auto()
+
+    # reductions
+    REDSUM = auto()
+    WREDSUM = auto()
+    WREDSUMU = auto()
+
+    REDMIN = auto()
+    REDMINU = auto()
+    REDMAX = auto()
+    REDMAXU = auto()
+
+    FREDUSUM = auto()
+    FWREDUSUM = auto()
+    FREDOSUM = auto()
+    FWREDOSUM = auto()
 
     VSETVLMAX = auto()
 
@@ -300,10 +318,8 @@ class OperationType(Enum):
             return "dot4asu"
         elif op_type == OperationType.DOT4AUS:
             return "dot4aus"
-        elif op_type == OperationType.QWDOTAU:
-            return "qwdotau"
-        elif op_type == OperationType.QWDOTAS:
-            return "qwdotas"
+        elif op_type == OperationType.QWDOTA:
+            return "qwdota"
         elif op_type == OperationType.FWDOTA:
             return "fwdota"
         elif op_type == OperationType.FQWDOTA:
@@ -389,6 +405,28 @@ class OperationType(Enum):
         elif op_type == OperationType.GEU:
             # assume unsigned integer comparison
             return "msgeu"
+        elif op_type == OperationType.REDSUM:
+            return "redsum"
+        elif op_type == OperationType.WREDSUM:
+            return "wredsum"
+        elif op_type == OperationType.WREDSUMU:
+            return "wredsumu"
+        elif op_type == OperationType.REDMIN:
+            return "redmin"
+        elif op_type == OperationType.REDMINU:
+            return "redminu"
+        elif op_type == OperationType.REDMAX:
+            return "redmax"
+        elif op_type == OperationType.REDMAXU:
+            return "redmaxu"
+        elif op_type == OperationType.FREDUSUM:
+            return "fredusum"
+        elif op_type == OperationType.FWREDUSUM:
+            return "fwredusum"
+        elif op_type == OperationType.FREDOSUM:
+            return "fredosum"
+        elif op_type == OperationType.FWREDOSUM:
+            return "fwredosum"
         else:
             raise ValueError(f"Invalid operation type: {op_type}")
 
@@ -607,7 +645,12 @@ def generate_intrinsic_name(prototype: Operation) -> str:
         intrinsic_type_tag = f"{source_type_tag}_{intrinsic_type_tag}"
         operand_type_descriptor = "_v"
 
-    # Some intrinsics (comparison), require the the source type to be displayed in the name
+    if prototype.op_desc.op_type in [OperationType.QWDOTA]:
+        source_type_tags = [generate_intrinsic_type_tag(arg.node_format) for arg in prototype.args[1:3]]
+        intrinsic_type_tag = f"{'_'.join(source_type_tags)}_{intrinsic_type_tag}"
+        operand_type_descriptor = "_vv"
+
+    # Some intrinsics (comparison), require the source type to be displayed in the name
     # suffix, but also require the full type descriptor to be used for the destination
     if prototype.op_desc.op_type in [OperationType.LT, OperationType.LE, OperationType.GT, OperationType.GE, OperationType.GEU]:
         source_type_tag = generate_intrinsic_type_tag(prototype.args[0].node_format)

--- a/src/rie_generator/core.py
+++ b/src/rie_generator/core.py
@@ -659,6 +659,12 @@ def generate_intrinsic_name(prototype: Operation) -> str:
     if prototype.op_desc.op_type in [OperationType.ZEXT_VF2]:
         operand_type_descriptor = ""
 
+    if prototype.op_desc.op_type in [OperationType.REDSUM, OperationType.WREDSUM, OperationType.WREDSUMU, OperationType.REDMAX, OperationType.REDMAXU, OperationType.REDMIN, OperationType.REDMINU, 
+                                     OperationType.FREDUSUM, OperationType.FWREDUSUM, OperationType.FREDOSUM, OperationType.FWREDOSUM]:
+        source_type_tag = generate_intrinsic_type_tag(prototype.args[0].node_format)
+        intrinsic_type_tag = f"{source_type_tag}_{intrinsic_type_tag}"
+        operand_type_descriptor = "_vs"    
+
     # if prototype.op_desc.op_type in [OperationType.MERGE]:
     #    # vmerge is always a v[vxi]m operation
     #    operand_type_descriptor += "m"

--- a/src/rie_generator/description_helper.py
+++ b/src/rie_generator/description_helper.py
@@ -1,7 +1,26 @@
 from typing import Callable
 from .core import TailPolicy, MaskPolicy, Operation, OperationDescriptor, NodeFormatDescriptor, NodeFormatType, EltType, LMULType, Immediate, OperationType, Node
 
-def emulate_with_split_lmul(result_fmt: NodeFormatDescriptor, operands: list, vl: Node, generator: Callable, generator_extra_args: list, tail_policy: TailPolicy, mask_policy: MaskPolicy, vm: Node, generator_extra_kwargs: dict) -> Operation:
+
+def assemble_split_result(result_fmt, result_hi, result_lo):
+    # CREATE: reassemble two half original LMUL results into full LMUL
+    result_elt = result_fmt.elt_type
+    full_result_fmt = NodeFormatDescriptor(NodeFormatType.VECTOR, result_elt, result_fmt.lmul_type)
+    result = Operation(full_result_fmt, OperationDescriptor(OperationType.CREATE),
+                       result_lo, result_hi)
+    return result
+
+def emulate_with_split_lmul(
+        result_fmt: NodeFormatDescriptor,
+        operands: list,
+        vl: Node,
+        generator: Callable,
+        generator_extra_args: list,
+        tail_policy: TailPolicy,
+        mask_policy: MaskPolicy,
+        vm: Node,
+        generator_extra_kwargs: dict,
+        assemble_fn: Callable[[NodeFormatDescriptor, Node, Node], Operation] = assemble_split_result) -> Operation:
     """ generator is expected to follow the Generator API """
     # check that LMUL can actually be split
     # 1. LMUL value must be large enough that half LMUL is still valid for EEW  
@@ -47,12 +66,7 @@ def emulate_with_split_lmul(result_fmt: NodeFormatDescriptor, operands: list, vl
     result_lo = generator(*args_lo, *generator_extra_args, vl=vl_lo, vm=None, tail_policy=TailPolicy.AGNOSTIC, mask_policy=MaskPolicy.UNMASKED, **generator_extra_kwargs)
     result_hi = generator(*args_hi, *generator_extra_args, vl=vl_hi, vm=None, tail_policy=TailPolicy.AGNOSTIC, mask_policy=MaskPolicy.UNMASKED, **generator_extra_kwargs)
 
-    # CREATE: reassemble two half original LMUL results into full LMUL
-    result_elt = result_fmt.elt_type
-    full_result_fmt = NodeFormatDescriptor(NodeFormatType.VECTOR, result_elt, result_fmt.lmul_type)
-    result = Operation(full_result_fmt, OperationDescriptor(OperationType.CREATE),
-                       result_lo, result_hi)
-    return result
+    return assemble_fn(result_fmt, result_hi, result_lo)
 
 def get_vlmax(elt_type: EltType, lmul_type: LMULType) -> Node:
     vl_fmt = NodeFormatDescriptor(NodeFormatType.VECTOR_LENGTH, EltType.SIZE_T, None)

--- a/src/rie_generator/zvdota_emulation.py
+++ b/src/rie_generator/zvdota_emulation.py
@@ -1,0 +1,392 @@
+import re
+
+"""
+Zvdota family of dot-product extensions emulation generator.
+
+This module generates C code for emulating RISC-V Zvdota vector
+dot-product instructions using standard RVV 1.0 intrinsics.
+
+The Zvdota family computes a dot product between two vector register groups
+(vs2 and vs1), producing a scalar result accumulated into element 0 of vd.
+Other elements of vd are tail and follow the tail agnostic/undisturbed policy.
+
+Sub-extensions covered:
+
+  Zvqwdota8i  — 8-bit integer dot product, 32-bit accumulation
+    vqwdotau.vv vd, vs2, vs1, vm   # unsigned(vs2) · vs1 (altfmt selects vs1 sign)
+    vqwdotas.vv vd, vs2, vs1, vm   # signed(vs2)   · vs1 (altfmt selects vs1 sign)
+    SEW=8, vd EEW=4*SEW=32, depends on Zve32x
+
+  Zvqwdota16i — 16-bit integer dot product, 64-bit accumulation
+    Same encodings as Zvqwdota8i but at SEW=16.
+    vd EEW=4*SEW=64, depends on Zve64x
+
+  Zvfwdota16bf — BF16 dot product, FP32 accumulation
+    vfwdota.vv vd, vs2, vs1, vm    # altfmt=1, SEW=16
+    vd EEW=2*SEW=32, depends on Zve32f
+
+  Zvfqwdota8f — OFP8 dot product, FP32 accumulation
+    vfqwdota.vv     vd, vs2, vs1, vm   # E4M3(vs2) · vs1 (altfmt selects vs1 fmt)
+    vfqwdota.alt.vv vd, vs2, vs1, vm   # E5M2(vs2) · vs1 (altfmt selects vs1 fmt)
+    SEW=8, vd EEW=4*SEW=32, depends on Zve32f
+
+Common properties:
+  - vs2 and vs1 have EMUL=LMUL, EEW=SEW
+  - vd always has EMUL=1
+  - These instructions are maskable
+  - vstart must be 0
+  - vd cannot overlap vs2 or vs1
+"""
+
+from .core import (
+    Operation,
+    OperationDescriptor,
+    NodeFormatDescriptor,
+    NodeFormatType,
+    Immediate,
+    Input,
+    Node,
+    EltType,
+    LMULType,
+    OperationType,
+    generate_intrinsic_name,
+    generate_intrinsic_prototype,
+    generate_intrinsic_from_operation,
+    TailPolicy,
+    MaskPolicy,
+)
+
+
+# ---------------------------------------------------------------------------
+# Emulation building blocks
+# ---------------------------------------------------------------------------
+
+def vqwdotau_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
+                       vm: Node, tail_policy: TailPolicy,
+                       mask_policy: MaskPolicy) -> Operation:
+    """Emulate vqwdotau.vv (unsigned 8-bit vs2 dot product, 32-bit accumulation).
+
+    TODO: implement emulation using base RVV 1.0 operations.
+    """
+    pass
+
+
+def vqwdotas_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
+                       vm: Node, tail_policy: TailPolicy,
+                       mask_policy: MaskPolicy) -> Operation:
+    """Emulate vqwdotas.vv (signed 8-bit vs2 dot product, 32-bit accumulation).
+
+    TODO: implement emulation using base RVV 1.0 operations.
+    """
+    pass
+
+
+def vfwdota_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
+                      vm: Node, tail_policy: TailPolicy,
+                      mask_policy: MaskPolicy) -> Operation:
+    """Emulate vfwdota.vv (BF16 dot product, FP32 accumulation).
+
+    TODO: implement emulation using base RVV 1.0 operations.
+    """
+    pass
+
+
+def vfqwdota_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
+                       vm: Node, tail_policy: TailPolicy,
+                       mask_policy: MaskPolicy) -> Operation:
+    """Emulate vfqwdota.vv (OFP8 E4M3 vs2 dot product, FP32 accumulation).
+
+    TODO: implement emulation using base RVV 1.0 operations.
+    """
+    pass
+
+
+def vfqwdota_alt_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
+                           vm: Node, tail_policy: TailPolicy,
+                           mask_policy: MaskPolicy) -> Operation:
+    """Emulate vfqwdota.alt.vv (OFP8 E5M2 vs2 dot product, FP32 accumulation).
+
+    TODO: implement emulation using base RVV 1.0 operations.
+    """
+    pass
+
+
+# ---------------------------------------------------------------------------
+# Valid parameter spaces
+# ---------------------------------------------------------------------------
+
+# Zvqwdota8i: SEW=8 sources, 32-bit accumulator, LMUL ∈ {1,2,4,8}
+ZVQWDOTA8I_VALID_LMULS = [LMULType.M1, LMULType.M2, LMULType.M4, LMULType.M8]
+
+# Zvqwdota16i: SEW=16 sources, 64-bit accumulator, LMUL ∈ {1,2,4,8}
+ZVQWDOTA16I_VALID_LMULS = [LMULType.M1, LMULType.M2, LMULType.M4, LMULType.M8]
+
+# Zvfwdota16bf: SEW=16 BF16 sources, FP32 accumulator, LMUL ∈ {1,2,4,8}
+ZVFWDOTA16BF_VALID_LMULS = [LMULType.M1, LMULType.M2, LMULType.M4, LMULType.M8]
+
+# Zvfqwdota8f: SEW=8 OFP8 sources, FP32 accumulator, LMUL ∈ {1,2,4,8}
+ZVFQWDOTA8F_VALID_LMULS = [LMULType.M1, LMULType.M2, LMULType.M4, LMULType.M8]
+
+
+# ---------------------------------------------------------------------------
+# Top-level generator
+# ---------------------------------------------------------------------------
+
+def generate_zvdota_emulation(
+    attributes: list[str] = [],
+    prototypes: bool = False,
+    definitions: bool = True,
+    lmul_filter: list = None,
+    tail_policy_filter: list = None,
+    mask_policy_filter: list = None,
+    label_filter: str = None,
+):
+    """Generate all Zvdota family instruction emulations.
+
+    Args:
+        attributes: list of attributes to add to the generated code
+        prototypes: if True, generate prototypes only
+        definitions: if True, generate definitions only
+        lmul_filter: if set, only generate for these LMULType values
+        tail_policy_filter: if set, only generate for these TailPolicy values
+        mask_policy_filter: if set, only generate for these MaskPolicy values
+        label_filter: regex pattern to filter generated intrinsics by name
+
+    Generates emulation code for:
+      - vqwdotau.vv   (Zvqwdota8i:  unsigned 8-bit vs2 → 32-bit accumulator)
+      - vqwdotas.vv   (Zvqwdota8i:  signed 8-bit vs2 → 32-bit accumulator)
+      - vfwdota.vv    (Zvfwdota16bf: BF16 → FP32 accumulator)
+      - vfqwdota.vv   (Zvfqwdota8f: OFP8 E4M3 vs2 → FP32 accumulator)
+      - vfqwdota.alt.vv (Zvfqwdota8f: OFP8 E5M2 vs2 → FP32 accumulator)
+
+    NOTE: Zvqwdota16i (SEW=16 → 64-bit) uses the same encodings as Zvqwdota8i
+          but at SEW=16.  It is not yet generated here since it would require
+          64-bit accumulator element types (S64/U64) which have limited
+          toolchain support.
+    """
+    output = []
+
+    vl_type = NodeFormatDescriptor(NodeFormatType.VECTOR_LENGTH, EltType.SIZE_T, None)
+    vl = Input(vl_type, 3, name="vl")
+
+    output.append("#include <stdint.h>\n")
+    output.append("#include <riscv_vector.h>\n")
+    output.append("#include <stddef.h>\n")
+
+    all_tail_policies = [TailPolicy.UNDISTURBED, TailPolicy.AGNOSTIC]
+    all_mask_policies = [MaskPolicy.UNDISTURBED, MaskPolicy.AGNOSTIC, MaskPolicy.UNMASKED]
+
+    tail_policies = [t for t in all_tail_policies if tail_policy_filter is None or t in tail_policy_filter]
+    mask_policies = [m for m in all_mask_policies if mask_policy_filter is None or m in mask_policy_filter]
+
+    # -----------------------------------------------------------------------
+    # Zvqwdota8i: vqwdotau.vv / vqwdotas.vv
+    #   SEW=8 inputs, 32-bit accumulator
+    #   vs2, vs1: EMUL=LMUL, EEW=8
+    #   vd: EMUL=1, EEW=32
+    # -----------------------------------------------------------------------
+    zvqwdota8i_lmuls = [l for l in ZVQWDOTA8I_VALID_LMULS if lmul_filter is None or l in lmul_filter]
+
+    for lmul in zvqwdota8i_lmuls:
+        for tail_policy in tail_policies:
+            for mask_policy in mask_policies:
+                # Source formats: unsigned and signed 8-bit at LMUL
+                vuint8_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.U8, lmul)
+                vint8_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.S8, lmul)
+                # Accumulator format: 32-bit at EMUL=1
+                vuint32_m1_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.U32, LMULType.M1)
+                vint32_m1_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.S32, LMULType.M1)
+                # Mask type is relative to vd (EMUL=1, EEW=32)
+                vbool32_t = NodeFormatDescriptor(NodeFormatType.MASK, EltType.U32, LMULType.M1)
+
+                # --- Inputs ---
+                vs2_u = Input(vuint8_t, 0, name="vs2")
+                vs1_u = Input(vuint8_t, 1, name="vs1")
+                vs2_s = Input(vint8_t, 0, name="vs2")
+                vs1_s = Input(vint8_t, 1, name="vs1")
+                vd_u = Input(vuint32_m1_t, 2, name="vd")
+                vd_s = Input(vint32_m1_t, 2, name="vd")
+                vm = Input(vbool32_t, -2, name="vm")
+
+                zvqwdota8i_insns = []
+
+                # --- vqwdotau.vv: unsigned vs2 ---
+                proto_qwdotau = Operation(
+                    vuint32_m1_t, OperationDescriptor(OperationType.QWDOTAU),
+                    vd_u, vs2_u, vs1_u, vl,
+                    dst=vd_u, tail_policy=tail_policy, mask_policy=mask_policy, vm=vm
+                )
+                emul_qwdotau = vqwdotau_emulation(vs2_u, vs1_u, vd_u, vl, vm, tail_policy, mask_policy)
+                zvqwdota8i_insns.append((proto_qwdotau, emul_qwdotau))
+
+                # --- vqwdotas.vv: signed vs2 ---
+                proto_qwdotas = Operation(
+                    vint32_m1_t, OperationDescriptor(OperationType.QWDOTAS),
+                    vd_s, vs2_s, vs1_s, vl,
+                    dst=vd_s, tail_policy=tail_policy, mask_policy=mask_policy, vm=vm
+                )
+                emul_qwdotas = vqwdotas_emulation(vs2_s, vs1_s, vd_s, vl, vm, tail_policy, mask_policy)
+                zvqwdota8i_insns.append((proto_qwdotas, emul_qwdotas))
+
+                lmul_str = LMULType.to_string(lmul)
+                tail_policy_str = TailPolicy.to_string(tail_policy)
+                mask_policy_str = MaskPolicy.to_string(mask_policy)
+
+                if label_filter is not None:
+                    zvqwdota8i_insns = [(p, e) for p, e in zvqwdota8i_insns if re.search(label_filter, generate_intrinsic_name(p))]
+                if prototypes:
+                    output.append(f"// Zvqwdota8i prototypes (LMUL={lmul_str}), tail_policy={tail_policy_str}, mask_policy={mask_policy_str}")
+                    for proto, _ in zvqwdota8i_insns:
+                        output.append(generate_intrinsic_prototype(proto))
+
+                if definitions:
+                    output.append(f"\n// Zvqwdota8i definitions (LMUL={lmul_str}), tail_policy={tail_policy_str}, mask_policy={mask_policy_str}")
+                    for proto, emul in zvqwdota8i_insns:
+                        if emul is not None:
+                            output.append(generate_intrinsic_from_operation(proto, emul, attributes=attributes))
+                        else:
+                            output.append(f"// TODO: emulation not yet implemented for {generate_intrinsic_name(proto)}")
+
+    # -----------------------------------------------------------------------
+    # Zvfwdota16bf: vfwdota.vv
+    #   SEW=16 BF16 inputs, FP32 accumulator
+    #   vs2, vs1: EMUL=LMUL, EEW=16
+    #   vd: EMUL=1, EEW=32
+    #   Requires altfmt=1
+    # -----------------------------------------------------------------------
+    # NOTE: BF16 is not natively supported in the current RVV type system.
+    #       The sources use EEW=16 (treated as BF16), and the accumulator is FP32.
+    #       We use U16 as a placeholder for BF16 element type.
+    zvfwdota16bf_lmuls = [l for l in ZVFWDOTA16BF_VALID_LMULS if lmul_filter is None or l in lmul_filter]
+
+    for lmul in zvfwdota16bf_lmuls:
+        for tail_policy in tail_policies:
+            for mask_policy in mask_policies:
+                # Source format: 16-bit (BF16 placeholder) at LMUL
+                vuint16_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.U16, lmul)
+                # Accumulator format: 32-bit at EMUL=1
+                vuint32_m1_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.U32, LMULType.M1)
+                # Mask type relative to vd (EMUL=1, EEW=32)
+                vbool32_t = NodeFormatDescriptor(NodeFormatType.MASK, EltType.U32, LMULType.M1)
+
+                vs2 = Input(vuint16_t, 0, name="vs2")
+                vs1 = Input(vuint16_t, 1, name="vs1")
+                vd = Input(vuint32_m1_t, 2, name="vd")
+                vm = Input(vbool32_t, -2, name="vm")
+
+                zvfwdota16bf_insns = []
+
+                proto_fwdota = Operation(
+                    vuint32_m1_t, OperationDescriptor(OperationType.FWDOTA),
+                    vd, vs2, vs1, vl,
+                    dst=vd, tail_policy=tail_policy, mask_policy=mask_policy, vm=vm
+                )
+                emul_fwdota = vfwdota_emulation(vs2, vs1, vd, vl, vm, tail_policy, mask_policy)
+                zvfwdota16bf_insns.append((proto_fwdota, emul_fwdota))
+
+                lmul_str = LMULType.to_string(lmul)
+                tail_policy_str = TailPolicy.to_string(tail_policy)
+                mask_policy_str = MaskPolicy.to_string(mask_policy)
+
+                if label_filter is not None:
+                    zvfwdota16bf_insns = [(p, e) for p, e in zvfwdota16bf_insns if re.search(label_filter, generate_intrinsic_name(p))]
+                if prototypes:
+                    output.append(f"// Zvfwdota16bf prototypes (LMUL={lmul_str}), tail_policy={tail_policy_str}, mask_policy={mask_policy_str}")
+                    for proto, _ in zvfwdota16bf_insns:
+                        output.append(generate_intrinsic_prototype(proto))
+
+                if definitions:
+                    output.append(f"\n// Zvfwdota16bf definitions (LMUL={lmul_str}), tail_policy={tail_policy_str}, mask_policy={mask_policy_str}")
+                    for proto, emul in zvfwdota16bf_insns:
+                        if emul is not None:
+                            output.append(generate_intrinsic_from_operation(proto, emul, attributes=attributes))
+                        else:
+                            output.append(f"// TODO: emulation not yet implemented for {generate_intrinsic_name(proto)}")
+
+    # -----------------------------------------------------------------------
+    # Zvfqwdota8f: vfqwdota.vv / vfqwdota.alt.vv
+    #   SEW=8 OFP8 inputs, FP32 accumulator
+    #   vs2, vs1: EMUL=LMUL, EEW=8
+    #   vd: EMUL=1, EEW=32
+    #   vfqwdota.vv     — E4M3(vs2), altfmt selects vs1 format
+    #   vfqwdota.alt.vv — E5M2(vs2), altfmt selects vs1 format
+    # -----------------------------------------------------------------------
+    # NOTE: OFP8 formats are not natively supported in the RVV type system.
+    #       We use U8 as a placeholder for the OFP8 element types.
+    zvfqwdota8f_lmuls = [l for l in ZVFQWDOTA8F_VALID_LMULS if lmul_filter is None or l in lmul_filter]
+
+    for lmul in zvfqwdota8f_lmuls:
+        for tail_policy in tail_policies:
+            for mask_policy in mask_policies:
+                # Source format: 8-bit (OFP8 placeholder) at LMUL
+                vuint8_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.U8, lmul)
+                # Accumulator format: 32-bit at EMUL=1
+                vuint32_m1_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.U32, LMULType.M1)
+                # Mask type relative to vd (EMUL=1, EEW=32)
+                vbool32_t = NodeFormatDescriptor(NodeFormatType.MASK, EltType.U32, LMULType.M1)
+
+                vs2 = Input(vuint8_t, 0, name="vs2")
+                vs1 = Input(vuint8_t, 1, name="vs1")
+                vd = Input(vuint32_m1_t, 2, name="vd")
+                vm = Input(vbool32_t, -2, name="vm")
+
+                zvfqwdota8f_insns = []
+
+                # --- vfqwdota.vv: E4M3(vs2) ---
+                proto_fqwdota = Operation(
+                    vuint32_m1_t, OperationDescriptor(OperationType.FQWDOTA),
+                    vd, vs2, vs1, vl,
+                    dst=vd, tail_policy=tail_policy, mask_policy=mask_policy, vm=vm
+                )
+                emul_fqwdota = vfqwdota_emulation(vs2, vs1, vd, vl, vm, tail_policy, mask_policy)
+                zvfqwdota8f_insns.append((proto_fqwdota, emul_fqwdota))
+
+                # --- vfqwdota.alt.vv: E5M2(vs2) ---
+                proto_fqwdota_alt = Operation(
+                    vuint32_m1_t, OperationDescriptor(OperationType.FQWDOTA_ALT),
+                    vd, vs2, vs1, vl,
+                    dst=vd, tail_policy=tail_policy, mask_policy=mask_policy, vm=vm
+                )
+                emul_fqwdota_alt = vfqwdota_alt_emulation(vs2, vs1, vd, vl, vm, tail_policy, mask_policy)
+                zvfqwdota8f_insns.append((proto_fqwdota_alt, emul_fqwdota_alt))
+
+                lmul_str = LMULType.to_string(lmul)
+                tail_policy_str = TailPolicy.to_string(tail_policy)
+                mask_policy_str = MaskPolicy.to_string(mask_policy)
+
+                if label_filter is not None:
+                    zvfqwdota8f_insns = [(p, e) for p, e in zvfqwdota8f_insns if re.search(label_filter, generate_intrinsic_name(p))]
+                if prototypes:
+                    output.append(f"// Zvfqwdota8f prototypes (LMUL={lmul_str}), tail_policy={tail_policy_str}, mask_policy={mask_policy_str}")
+                    for proto, _ in zvfqwdota8f_insns:
+                        output.append(generate_intrinsic_prototype(proto))
+
+                if definitions:
+                    output.append(f"\n// Zvfqwdota8f definitions (LMUL={lmul_str}), tail_policy={tail_policy_str}, mask_policy={mask_policy_str}")
+                    for proto, emul in zvfqwdota8f_insns:
+                        if emul is not None:
+                            output.append(generate_intrinsic_from_operation(proto, emul, attributes=attributes))
+                        else:
+                            output.append(f"// TODO: emulation not yet implemented for {generate_intrinsic_name(proto)}")
+
+    return "\n".join(output)
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(attributes: list[str] = [], prototypes: bool = False, definitions: bool = True):
+    """CLI entry point for generating Zvdota emulation code."""
+    print(generate_zvdota_emulation(attributes=attributes, prototypes=prototypes, definitions=definitions))
+
+
+if __name__ == "__main__":
+    import argparse
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-a", "--attributes", nargs="+", default=[], help="Attributes to add to the generated code")
+    parser.add_argument("-p", "--prototypes", default=False, action="store_true", help="generate prototypes")
+    parser.add_argument("--no-definitions", default=True, action="store_false", help="do not generate definitions")
+    args = parser.parse_args()
+
+    main(attributes=args.attributes, prototypes=args.prototypes, definitions=not args.no_definitions)

--- a/src/rie_generator/zvdota_emulation.py
+++ b/src/rie_generator/zvdota_emulation.py
@@ -61,14 +61,58 @@ from .core import (
 # Emulation building blocks
 # ---------------------------------------------------------------------------
 
-def vqwdotau_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
+def vqwdota_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
                        vm: Node, tail_policy: TailPolicy,
                        mask_policy: MaskPolicy) -> Operation:
-    """Emulate vqwdotau.vv (unsigned 8-bit vs2 dot product, 32-bit accumulation).
+    """Emulate vqwdota.vv (signed or unsigned 8-bit vs2 dot product, 32-bit accumulation).
 
-    TODO: implement emulation using base RVV 1.0 operations.
+        Signs are determined from vs2 and vs1 formats.
+        The intrinsics expose a single API which is mapped to either vqwdotau.vv or vqwdotas.vv based on the element types.
+        For u8 vs u8 => vqwdotau.vv
+        For u8 vs i8 => vqwdotau.vv
+        For i8 vs u8 => vqwdotas.vv
+        For i8 vs i8 => vqwdotas.vv
+
+        vs1 signedness is encoded in vtype.atlfmt (0: unsigned, 1: signed)
+
     """
-    pass
+    prod_format = EltType.widen(vs2.node_format.elt_type)
+    if EltType.is_signed(vs2.node_format.elt_type) and EltType.is_signed(vs1.node_format.elt_type):
+        mul_op = OperationType.WMUL
+        red_op = OperationType.WREDSUM
+    elif EltType.is_unsigned(vs2.node_format.elt_type) and EltType.is_unsigned(vs1.node_format.elt_type):
+        mul_op = OperationType.WMULU
+        red_op = OperationType.WREDSUMU
+    else:
+        mul_op = OperationType.WMULSU
+        red_op = OperationType.WREDSUM
+    # widening product
+    products = Operation(
+        NodeFormatDescriptor(NodeFormatType.VECTOR, prod_format, vs2.node_format.lmul_type),
+        OperationDescriptor(mul_op),
+        # swapping operands to ensure the first operand is signed if at least one of vs2/vs1 are signed
+        vs2 if EltType.is_signed(vs2.node_format.elt_type) else vs1,
+        vs1 if EltType.is_signed(vs2.node_format.elt_type) else vs2,
+        vl,
+    )
+    # widening reduction
+    red_format = vd.node_format
+    reduced = Operation(
+        red_format,
+        OperationDescriptor(red_op),
+        products,
+        vd,
+        vl,
+        vm=vm,
+        dst=vd,
+        tail_policy=tail_policy,
+        mask_policy=mask_policy,
+    )
+
+    return reduced
+    
+    
+    
 
 
 def vqwdotas_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
@@ -212,20 +256,20 @@ def generate_zvdota_emulation(
 
                 # --- vqwdotau.vv: unsigned vs2 ---
                 proto_qwdotau = Operation(
-                    vuint32_m1_t, OperationDescriptor(OperationType.QWDOTAU),
+                    vuint32_m1_t, OperationDescriptor(OperationType.QWDOTA),
                     vd_u, vs2_u, vs1_u, vl,
                     dst=vd_u, tail_policy=tail_policy, mask_policy=mask_policy, vm=vm
                 )
-                emul_qwdotau = vqwdotau_emulation(vs2_u, vs1_u, vd_u, vl, vm, tail_policy, mask_policy)
+                emul_qwdotau = vqwdota_emulation(vs2_u, vs1_u, vd_u, vl, vm, tail_policy, mask_policy)
                 zvqwdota8i_insns.append((proto_qwdotau, emul_qwdotau))
 
                 # --- vqwdotas.vv: signed vs2 ---
                 proto_qwdotas = Operation(
-                    vint32_m1_t, OperationDescriptor(OperationType.QWDOTAS),
+                    vint32_m1_t, OperationDescriptor(OperationType.QWDOTA),
                     vd_s, vs2_s, vs1_s, vl,
                     dst=vd_s, tail_policy=tail_policy, mask_policy=mask_policy, vm=vm
                 )
-                emul_qwdotas = vqwdotas_emulation(vs2_s, vs1_s, vd_s, vl, vm, tail_policy, mask_policy)
+                emul_qwdotas = vqwdota_emulation(vs2_s, vs1_s, vd_s, vl, vm, tail_policy, mask_policy)
                 zvqwdota8i_insns.append((proto_qwdotas, emul_qwdotas))
 
                 lmul_str = LMULType.to_string(lmul)

--- a/src/rie_generator/zvdota_emulation.py
+++ b/src/rie_generator/zvdota_emulation.py
@@ -56,14 +56,17 @@ from .core import (
     MaskPolicy,
 )
 
+from .description_helper import emulate_with_split_lmul
+
 
 # ---------------------------------------------------------------------------
 # Emulation building blocks
 # ---------------------------------------------------------------------------
 
 def vqwdota_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
-                       vm: Node, tail_policy: TailPolicy,
-                       mask_policy: MaskPolicy) -> Operation:
+                       tail_policy: TailPolicy = TailPolicy.AGNOSTIC,
+                       mask_policy: MaskPolicy = MaskPolicy.UNMASKED,
+                       vm: Node = None) -> Operation:
     """Emulate vqwdota.vv (signed or unsigned 8-bit vs2 dot product, 32-bit accumulation).
 
         Signs are determined from vs2 and vs1 formats.
@@ -76,7 +79,44 @@ def vqwdota_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
         vs1 signedness is encoded in vtype.atlfmt (0: unsigned, 1: signed)
 
     """
-    prod_format = EltType.widen(vs2.node_format.elt_type)
+    lmul = vs2.node_format.lmul_type
+    # M8 and M4 splitting: split into two M4 halves, process independently, reassemble
+    if lmul in [LMULType.M4, LMULType.M8]:
+        half_lmul = LMULType.divide(lmul, 2)
+
+        # FIXME: the following helper functions have been copied from description_helper.emulate_with_split_lmul.
+        # they should be factorized
+        idx_fmt = NodeFormatDescriptor(NodeFormatType.IMMEDIATE, EltType.SIZE_T)
+        # Derive M4/M8 formats from each input's own element type
+        def make_half_lmul_format(node):
+            return NodeFormatDescriptor(NodeFormatType.VECTOR, node.node_format.elt_type, half_lmul)
+        def get_halves(node):
+            half_lmul_format = make_half_lmul_format(node)
+            lo = Operation(half_lmul_format, OperationDescriptor(OperationType.GET), node, Immediate(idx_fmt, 0))
+            hi = Operation(half_lmul_format, OperationDescriptor(OperationType.GET), node, Immediate(idx_fmt, 1))
+            return lo, hi
+
+        vl_fmt = NodeFormatDescriptor(NodeFormatType.VECTOR_LENGTH, EltType.SIZE_T, None)
+        vs2_split = get_halves(vs2)
+        vs1_split = get_halves(vs1)
+
+        half_lmul_result_fmt = NodeFormatDescriptor(NodeFormatType.PLACEHOLDER, vs2.node_format.elt_type, half_lmul)
+        placeholder = Immediate(half_lmul_result_fmt, None)
+        vlmax_half_lmul = Operation(vl_fmt, OperationDescriptor(OperationType.VSETVLMAX), placeholder)
+
+        # vl_half = vl / 2
+        vl_lo = Operation(vl_fmt, OperationDescriptor(OperationType.MIN),
+                        vl, vlmax_half_lmul)
+        vl_hi = Operation(vl_fmt, OperationDescriptor(OperationType.SUB),
+                            vl, vl_lo)
+
+        result_lo = vqwdota_emulation(vs2_split[0], vs1_split[0], vd, vl_lo, tail_policy=TailPolicy.AGNOSTIC, mask_policy=MaskPolicy.UNMASKED, vm=None)
+        result_hi = vqwdota_emulation(vs2_split[1], vs1_split[1], result_lo, vl_hi, tail_policy=TailPolicy.AGNOSTIC, mask_policy=MaskPolicy.UNMASKED, vm=None)
+
+        return result_hi
+
+    prod_elt_format = EltType.widen(vs2.node_format.elt_type)
+    prod_format = NodeFormatDescriptor(NodeFormatType.VECTOR, prod_elt_format, LMULType.multiply(vs2.node_format.lmul_type, 2))
     if EltType.is_signed(vs2.node_format.elt_type) and EltType.is_signed(vs1.node_format.elt_type):
         mul_op = OperationType.WMUL
         red_op = OperationType.WREDSUM
@@ -88,13 +128,18 @@ def vqwdota_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
         red_op = OperationType.WREDSUM
     # widening product
     products = Operation(
-        NodeFormatDescriptor(NodeFormatType.VECTOR, prod_format, vs2.node_format.lmul_type),
+        prod_format,
         OperationDescriptor(mul_op),
         # swapping operands to ensure the first operand is signed if at least one of vs2/vs1 are signed
         vs2 if EltType.is_signed(vs2.node_format.elt_type) else vs1,
         vs1 if EltType.is_signed(vs2.node_format.elt_type) else vs2,
         vl,
     )
+    # Reduction intrinsincs do not care about the actual mask policy (agnostic/undisturbed),
+    # only masked/unmasked is relevant.
+    reduction_mask_policy = mask_policy
+    if mask_policy != MaskPolicy.UNMASKED:
+        reduction_mask_policy = MaskPolicy.AGNOSTIC
     # widening reduction
     red_format = vd.node_format
     reduced = Operation(
@@ -105,8 +150,8 @@ def vqwdota_emulation(vs2: Node, vs1: Node, vd: Node, vl: Node,
         vl,
         vm=vm,
         dst=vd,
-        tail_policy=tail_policy,
-        mask_policy=mask_policy,
+        tail_policy=TailPolicy.AGNOSTIC,
+        mask_policy=reduction_mask_policy,
     )
 
     return reduced
@@ -240,8 +285,8 @@ def generate_zvdota_emulation(
                 # Accumulator format: 32-bit at EMUL=1
                 vuint32_m1_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.U32, LMULType.M1)
                 vint32_m1_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.S32, LMULType.M1)
-                # Mask type is relative to vd (EMUL=1, EEW=32)
-                vbool32_t = NodeFormatDescriptor(NodeFormatType.MASK, EltType.U32, LMULType.M1)
+                # Mask type is relative to vs1/vs2
+                vbool_t = NodeFormatDescriptor(NodeFormatType.MASK, EltType.U8, lmul)
 
                 # --- Inputs ---
                 vs2_u = Input(vuint8_t, 0, name="vs2")
@@ -250,7 +295,7 @@ def generate_zvdota_emulation(
                 vs1_s = Input(vint8_t, 1, name="vs1")
                 vd_u = Input(vuint32_m1_t, 2, name="vd")
                 vd_s = Input(vint32_m1_t, 2, name="vd")
-                vm = Input(vbool32_t, -2, name="vm")
+                vm = Input(vbool_t, -2, name="vm")
 
                 zvqwdota8i_insns = []
 
@@ -260,7 +305,7 @@ def generate_zvdota_emulation(
                     vd_u, vs2_u, vs1_u, vl,
                     dst=vd_u, tail_policy=tail_policy, mask_policy=mask_policy, vm=vm
                 )
-                emul_qwdotau = vqwdota_emulation(vs2_u, vs1_u, vd_u, vl, vm, tail_policy, mask_policy)
+                emul_qwdotau = vqwdota_emulation(vs2_u, vs1_u, vd_u, vl, tail_policy, mask_policy, vm)
                 zvqwdota8i_insns.append((proto_qwdotau, emul_qwdotau))
 
                 # --- vqwdotas.vv: signed vs2 ---
@@ -269,7 +314,7 @@ def generate_zvdota_emulation(
                     vd_s, vs2_s, vs1_s, vl,
                     dst=vd_s, tail_policy=tail_policy, mask_policy=mask_policy, vm=vm
                 )
-                emul_qwdotas = vqwdota_emulation(vs2_s, vs1_s, vd_s, vl, vm, tail_policy, mask_policy)
+                emul_qwdotas = vqwdota_emulation(vs2_s, vs1_s, vd_s, vl, tail_policy, mask_policy, vm)
                 zvqwdota8i_insns.append((proto_qwdotas, emul_qwdotas))
 
                 lmul_str = LMULType.to_string(lmul)
@@ -311,12 +356,12 @@ def generate_zvdota_emulation(
                 # Accumulator format: 32-bit at EMUL=1
                 vuint32_m1_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.U32, LMULType.M1)
                 # Mask type relative to vd (EMUL=1, EEW=32)
-                vbool32_t = NodeFormatDescriptor(NodeFormatType.MASK, EltType.U32, LMULType.M1)
+                vbool_t = NodeFormatDescriptor(NodeFormatType.MASK, EltType.U16, lmul)
 
                 vs2 = Input(vuint16_t, 0, name="vs2")
                 vs1 = Input(vuint16_t, 1, name="vs1")
                 vd = Input(vuint32_m1_t, 2, name="vd")
-                vm = Input(vbool32_t, -2, name="vm")
+                vm = Input(vbool_t, -2, name="vm")
 
                 zvfwdota16bf_insns = []
 
@@ -366,13 +411,13 @@ def generate_zvdota_emulation(
                 vuint8_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.U8, lmul)
                 # Accumulator format: 32-bit at EMUL=1
                 vuint32_m1_t = NodeFormatDescriptor(NodeFormatType.VECTOR, EltType.U32, LMULType.M1)
-                # Mask type relative to vd (EMUL=1, EEW=32)
-                vbool32_t = NodeFormatDescriptor(NodeFormatType.MASK, EltType.U32, LMULType.M1)
+                # Mask type relative to vs1/vs2
+                vbool_t = NodeFormatDescriptor(NodeFormatType.MASK, EltType.U8, lmul)
 
                 vs2 = Input(vuint8_t, 0, name="vs2")
                 vs1 = Input(vuint8_t, 1, name="vs1")
                 vd = Input(vuint32_m1_t, 2, name="vd")
-                vm = Input(vbool32_t, -2, name="vm")
+                vm = Input(vbool_t, -2, name="vm")
 
                 zvfqwdota8f_insns = []
 


### PR DESCRIPTION
Implementing long dot product intrinsics emulation. This patch emulates the instructions describes in https://github.com/riscv/riscv-isa-manual/pull/2618/.

Implementing Zvdota intrinsics API as described in https://github.com/riscv-non-isa/riscv-rvv-intrinsic-doc/pull/427/


```
$ python3 scripts/generate_emulation.py --extension zvdota --label-filter vqwdota --lmul m1

/* ===== Zvdota Emulation ===== */
#include <stdint.h>

#include <riscv_vector.h>

#include <stddef.h>


// Zvqwdota8i definitions (LMUL=m1), tail_policy=undisturbed, mask_policy=undisturbed
 vuint32m1_t __riscv_vqwdota_vv_u8m1_u8m1_u32m1_tumu(vbool32_t vm, vuint32m1_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
  vuint16m1_t tmp0 = __riscv_vwmulu_vv_u16m1(vs1, vs2, vl);
  vuint32m1_t tmp1 = __riscv_vwredsumu_vv_u32m1_tumu(vm, vd, tmp0, vd, vl);
  return tmp1;
}
 vint32m1_t __riscv_vqwdota_vv_i8m1_i8m1_i32m1_tumu(vbool32_t vm, vint32m1_t vd, vint8m1_t vs2, vint8m1_t vs1, size_t vl) {
  vint16m1_t tmp0 = __riscv_vwmul_vv_i16m1(vs2, vs1, vl);
  vint32m1_t tmp1 = __riscv_vwredsum_vv_i32m1_tumu(vm, vd, tmp0, vd, vl);
  return tmp1;
}

// Zvqwdota8i definitions (LMUL=m1), tail_policy=undisturbed, mask_policy=agnostic
 vuint32m1_t __riscv_vqwdota_vv_u8m1_u8m1_u32m1_tum(vbool32_t vm, vuint32m1_t vd, vuint8m1_t vs2, vuint8m1_t vs1, size_t vl) {
  vuint16m1_t tmp0 = __riscv_vwmulu_vv_u16m1(vs1, vs2, vl);
  vuint32m1_t tmp1 = __riscv_vwredsumu_vv_u32m1_tum(vm, vd, tmp0, vd, vl);
  return tmp1;
}
(...)
```